### PR TITLE
Certora has updated the syntax for optimistic_fallback. The one shown in the course is no longer valid.

### DIFF
--- a/certora/conf/GasBadNft.conf
+++ b/certora/conf/GasBadNft.conf
@@ -9,7 +9,5 @@
     "rule_sanity": "basic",
     "optimistic_loop": true,
     "msg": "Verification of NftMarketplace",
-    "prover_args": [
-        "-optimisticFallback true"
-    ]
+    "optimistic_fallback": true
 }


### PR DESCRIPTION
### **Pull Request Description**

This Pull Request updates the Certora configuration to use the new CLI syntax introduced in **version 7.0.7 (March 15, 2024)**. The course currently uses outdated syntax:

```json
"prover_args": [
    "-optimisticFallback true"
]
```

The correct syntax is now:

```json
"optimistic_fallback": true
```

### **Key Changes in Certora 7.0.7**
1. `--prover_args '-optimisticFallback true'` replaced by `--optimistic_fallback`.


I hope this update can avoid potential confusion for users. 
AGMASO :)