### PR TITLE
An update due to CVL syntax change

### DIFF
--- a/certora/spec/GasBadNft.spec
+++ b/certora/spec/GasBadNft.spec
@@ -40,7 +40,7 @@ ghost mathint log4Count {
 }
 
 // Can't do `s_listings[KEY address nftAddress][KEY uint256 tokenId]` since that returns a struct
-hook Sstore s_listings[KEY address nftAddress][KEY uint256 tokenId].price uint256 price STORAGE {
+hook Sstore s_listings[KEY address nftAddress][KEY uint256 tokenId].price uint256 price {
     listingUpdatesCount = listingUpdatesCount + 1;
 }
 

--- a/certora/spec/NftMock.spec
+++ b/certora/spec/NftMock.spec
@@ -27,6 +27,7 @@ rule minting_mints_one_nft() {
     // This could be uint256 or mathint
     // You could do `balanceOf(minter)` instead of `nft.balanceOf(minter)` but I like to be explicit
     mathint balanceBefore = nft.balanceOf(minter);
+    require balanceBefore < max_uint256;
 
     // Act 
     currentContract.mint(e); 


### PR DESCRIPTION
The keyword "STORAGE" is no longer allowed when declaring hooks. (It had been option for a while but phased out as of certora-cli 8.0.0)

Also, added a require statement to avoid a counterexample that wasn't shown in the course.