### PR TITLE
Remove --no-commit flag from forge install commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ clean  :; forge clean
 # Remove modules
 remove :; rm -rf .gitmodules && rm -rf .git/modules/* && rm -rf lib && touch .gitmodules && git add . && git commit -m "modules"
 
-install :; forge install foundry-rs/forge-std --no-commit && forge install openzeppelin/openzeppelin-contracts --no-commit
+install :; forge install foundry-rs/forge-std && forge install openzeppelin/openzeppelin-contracts
 
 # Update Dependencies
 update:; forge update


### PR DESCRIPTION
## Summary
- Removes `--no-commit` flag from forge install commands in Makefile

## Test plan
- [x] Verified `forge build` succeeds